### PR TITLE
Add login and layout templates

### DIFF
--- a/src/main/resources/templates/auth/LoginForm.html
+++ b/src/main/resources/templates/auth/LoginForm.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>로그인</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex items-center justify-center min-h-screen">
+    <div class="bg-white p-8 rounded shadow-md w-full max-w-sm">
+        <h2 class="text-2xl font-bold text-center mb-6">로그인</h2>
+        <form action="/login" method="post" class="space-y-4">
+            <div>
+                <label for="userid" class="block text-sm font-medium text-gray-700">아이디</label>
+                <input type="text" id="userid" name="userid" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" required>
+            </div>
+            <div>
+                <label for="password" class="block text-sm font-medium text-gray-700">비밀번호</label>
+                <input type="password" id="password" name="password" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" required>
+            </div>
+            <div class="flex justify-end">
+                <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700">로그인</button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/Footer.html
+++ b/src/main/resources/templates/layout/Footer.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Footer</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+<footer class="bg-gray-100 text-gray-600 text-center p-4" th:fragment="footer">
+    <p>&copy; 2025 CMMS. All rights reserved.</p>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/layout/Header.html
+++ b/src/main/resources/templates/layout/Header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Header</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+<header class="bg-blue-600 text-white p-4" th:fragment="header">
+    <div class="container mx-auto flex items-center justify-between">
+        <h1 class="text-xl font-bold">CMMS</h1>
+        <nav>
+            <a href="#" class="mr-4 hover:underline">공지사항</a>
+            <a href="#" class="hover:underline">로그아웃</a>
+        </nav>
+    </div>
+</header>
+</body>
+</html>

--- a/src/main/resources/templates/layout/Layout.html
+++ b/src/main/resources/templates/layout/Layout.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Layout</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <div th:replace="layout/Header :: header"></div>
+    <div class="flex flex-1">
+        <aside class="w-64 bg-gray-100 p-4">
+            <nav class="space-y-2">
+                <div>
+                    <h3 class="font-semibold text-gray-700">Memo</h3>
+                    <ul class="ml-4 text-sm text-gray-600">
+                        <li><a href="/memo/form" class="hover:underline">입력(form)</a></li>
+                        <li><a href="/memo/list" class="hover:underline">목록(list)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold text-gray-700">Plant 기준정보</h3>
+                    <ul class="ml-4 text-sm text-gray-600">
+                        <li><a href="/plant/form" class="hover:underline">입력(form)</a></li>
+                        <li><a href="/plant/list" class="hover:underline">목록(list)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold text-gray-700">Inventory 기준정보</h3>
+                    <ul class="ml-4 text-sm text-gray-600">
+                        <li><a href="/inventory/form" class="hover:underline">입력(form)</a></li>
+                        <li><a href="/inventory/list" class="hover:underline">목록(list)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold text-gray-700">Inspection</h3>
+                    <ul class="ml-4 text-sm text-gray-600">
+                        <li><a href="/inspection/form" class="hover:underline">입력(form)</a></li>
+                        <li><a href="/inspection/list" class="hover:underline">목록(list)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold text-gray-700">Workorder</h3>
+                    <ul class="ml-4 text-sm text-gray-600">
+                        <li><a href="/workorder/form" class="hover:underline">입력(form)</a></li>
+                        <li><a href="/workorder/list" class="hover:underline">목록(list)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold text-gray-700">공통코드 관리</h3>
+                    <ul class="ml-4 text-sm text-gray-600">
+                        <li><a href="/code/form" class="hover:underline">입력(form)</a></li>
+                        <li><a href="/code/list" class="hover:underline">목록(list)</a></li>
+                    </ul>
+                </div>
+            </nav>
+        </aside>
+        <main class="flex-1 p-6" id="content">
+            <!-- 본문 컨텐츠 -->
+            <div class="text-gray-700">내용 영역</div>
+        </main>
+    </div>
+    <div th:replace="layout/Footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/memo/MemoDetail.html
+++ b/src/main/resources/templates/memo/MemoDetail.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>메모 상세 정보</title>
+    <!-- Tailwind CSS CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+        .section-header-h5 {
+            @apply text-base font-bold text-gray-800 mb-4;
+        }
+    </style>
+</head>
+<body class="bg-gray-100 p-6">
+    <div class="max-w-4xl mx-auto bg-white p-8 rounded-lg shadow-md">
+        <h2 class="text-3xl font-bold text-gray-800 mb-6">메모 상세 정보</h2>
+
+        <!-- 메모 정보 -->
+        <div class="mb-6">
+            <div class="grid grid-cols-1 gap-y-2 text-sm">
+                <div><span class="font-medium text-gray-800">메모 ID:</span> <span class="text-gray-700">MEMO240001</span></div>
+                <div><span class="font-medium text-gray-800">대상 유형:</span> <span class="text-gray-700">PLANT</span></div>
+                <div><span class="font-medium text-gray-800">대상 ID:</span> <span class="text-gray-700">PLT2406210001</span></div>
+                <div><span class="font-medium text-gray-800">제목:</span> <span class="text-gray-700">점검 결과 기록</span></div>
+                <div><span class="font-medium text-gray-800">작성자:</span> <span class="text-gray-700">홍길동</span></div>
+                <div><span class="font-medium text-gray-800">작성일시:</span> <span class="text-gray-700">2024-06-21 10:00</span></div>
+            </div>
+            <div class="mt-4 p-4 bg-gray-50 rounded-md border border-gray-300">
+                <p class="text-gray-700 text-sm">여기에 메모 내용이 표시됩니다. 설비 점검 결과 이상 없음을 확인했고 다음 점검은 한 달 후로 예정합니다.</p>
+            </div>
+        </div>
+
+        <!-- 첨부 파일 -->
+        <div class="mb-6">
+            <h5 class="section-header-h5">첨부 파일</h5>
+            <ul class="list-disc list-inside text-sm text-gray-700">
+                <li><a href="#" class="text-blue-600 hover:underline">점검사진.jpg</a></li>
+            </ul>
+        </div>
+
+        <!-- 댓글 -->
+        <div class="mb-6">
+            <h5 class="section-header-h5">댓글</h5>
+            <div class="space-y-4 text-sm">
+                <div class="border p-3 rounded-md bg-gray-50">
+                    <div class="font-medium text-gray-800">관리자 <span class="text-gray-500 text-xs">2024-06-21 11:00</span></div>
+                    <p class="text-gray-700 mt-1">점검 결과 공유 감사합니다.</p>
+                </div>
+            </div>
+            <div class="mt-4">
+                <textarea id="commentContent" rows="3" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" placeholder="댓글을 입력하세요..."></textarea>
+                <div class="flex justify-end mt-2">
+                    <button class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">댓글 등록</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- 하단 버튼 -->
+        <div class="mt-6 flex justify-end space-x-3">
+            <a href="MemoList.html" class="px-4 py-2 bg-gray-300 text-gray-800 font-semibold rounded-md shadow-sm hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2">목록으로</a>
+            <a href="MemoForm.html?memoId=MEMO240001" class="px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">수정</a>
+            <button class="px-4 py-2 bg-red-600 text-white font-semibold rounded-md shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">삭제</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/memo/MemoForm.html
+++ b/src/main/resources/templates/memo/MemoForm.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>메모 등록/수정</title>
+    <!-- Tailwind CSS CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+        .section-header {
+            @apply text-lg font-semibold text-gray-700 mb-4 pb-2 border-b border-gray-200;
+        }
+    </style>
+</head>
+<body class="bg-gray-100 p-6">
+    <div class="max-w-3xl mx-auto bg-white p-8 rounded-lg shadow-md">
+        <h2 class="text-3xl font-bold text-gray-800 mb-6">메모 등록/수정</h2>
+
+        <form action="#" method="POST">
+            <div class="grid grid-cols-2 gap-6">
+                <div>
+                    <label for="targetType" class="block text-sm font-medium text-gray-700">대상 유형 <span class="text-red-500">*</span></label>
+                    <select id="targetType" name="targetType" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" required>
+                        <option value="">선택하세요</option>
+                        <option value="PLANT">설비</option>
+                        <option value="INVENTORY">재고</option>
+                        <option value="WORKORD">작업 오더</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="targetId" class="block text-sm font-medium text-gray-700">대상 ID <span class="text-red-500">*</span></label>
+                    <input type="text" id="targetId" name="targetId" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" required>
+                </div>
+            </div>
+
+            <div class="mt-6">
+                <label for="memoName" class="block text-sm font-medium text-gray-700">제목 <span class="text-red-500">*</span></label>
+                <input type="text" id="memoName" name="memoName" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" required>
+            </div>
+
+            <div class="mt-6">
+                <label for="memoContent" class="block text-sm font-medium text-gray-700">메모 내용 <span class="text-red-500">*</span></label>
+                <textarea id="memoContent" name="memoContent" rows="6" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2" required></textarea>
+            </div>
+
+            <div class="mt-6">
+                <label for="createBy" class="block text-sm font-medium text-gray-700">작성자</label>
+                <input type="text" id="createBy" name="createBy" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2">
+            </div>
+
+            <!-- 파일 첨부 -->
+            <h5 class="section-header mt-8">첨부 파일</h5>
+            <div class="mb-8">
+                <div class="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
+                    <div class="space-y-1 text-center">
+                        <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+                            <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4m32-4V12a4 4 0 00-4-4H12a4 4 0 00-4 4v12" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                        </svg>
+                        <div class="flex text-sm text-gray-600">
+                            <label for="file-upload" class="relative cursor-pointer bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500">
+                                <span>파일 업로드</span>
+                                <input id="file-upload" name="file-upload" type="file" class="sr-only">
+                            </label>
+                            <p class="pl-1">또는 드래그 앤 드롭</p>
+                        </div>
+                        <p class="text-xs text-gray-500">PNG, JPG, GIF 최대 10MB</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mt-6 flex justify-end space-x-3">
+                <a href="MemoList.html" class="px-4 py-2 bg-gray-300 text-gray-800 font-semibold rounded-md shadow-sm hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2">
+                    목록으로
+                </a>
+                <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                    저장
+                </button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/memo/MemoList.html
+++ b/src/main/resources/templates/memo/MemoList.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>메모 목록</title>
+    <!-- Tailwind CSS CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+    </style>
+</head>
+<body class="bg-gray-100 p-6">
+    <div class="max-w-7xl mx-auto bg-white p-8 rounded-lg shadow-md">
+        <h2 class="text-3xl font-bold text-gray-800 mb-6">메모 목록</h2>
+
+        <!-- 검색 및 필터링 -->
+        <div class="mb-6 bg-gray-50 p-4 rounded-lg shadow-sm">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div>
+                    <label for="targetType" class="block text-sm font-medium text-gray-700">대상 유형</label>
+                    <select id="targetType" name="targetType" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2">
+                        <option value="">전체</option>
+                        <option value="PLANT">설비</option>
+                        <option value="INVENTORY">재고</option>
+                        <option value="WORKORD">작업 오더</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="targetId" class="block text-sm font-medium text-gray-700">대상 ID</label>
+                    <input type="text" id="targetId" name="targetId" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2">
+                </div>
+                <div>
+                    <label for="memoName" class="block text-sm font-medium text-gray-700">제목</label>
+                    <input type="text" id="memoName" name="memoName" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2">
+                </div>
+                <div>
+                    <label for="createBy" class="block text-sm font-medium text-gray-700">작성자</label>
+                    <input type="text" id="createBy" name="createBy" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2">
+                </div>
+            </div>
+            <div class="flex justify-end mt-4">
+                <button class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                    검색
+                </button>
+            </div>
+        </div>
+
+        <!-- 메모 목록 테이블 -->
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 rounded-lg overflow-hidden">
+                <thead class="bg-blue-500 text-white">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">메모 ID</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">제목</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">작성자</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">작성일시</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">액션</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    <tr>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">MEMO240001</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">점검 결과 기록</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">홍길동</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">2024-06-21 10:00</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                            <a href="MemoDetail.html?memoId=MEMO240001" class="text-blue-600 hover:text-blue-900 mr-2">상세</a>
+                            <a href="MemoForm.html?memoId=MEMO240001" class="text-indigo-600 hover:text-indigo-900 mr-2">수정</a>
+                            <button class="text-red-600 hover:text-red-900">삭제</button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">MEMO240002</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">교체 필요 부품 메모</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">김철수</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">2024-06-22 14:20</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                            <a href="MemoDetail.html?memoId=MEMO240002" class="text-blue-600 hover:text-blue-900 mr-2">상세</a>
+                            <a href="MemoForm.html?memoId=MEMO240002" class="text-indigo-600 hover:text-indigo-900 mr-2">수정</a>
+                            <button class="text-red-600 hover:text-red-900">삭제</button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- 하단 버튼 및 페이징 -->
+        <div class="mt-6 flex justify-between items-center">
+            <a href="MemoForm.html" class="px-4 py-2 bg-green-600 text-white font-semibold rounded-md shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
+                신규 메모 등록
+            </a>
+            <nav class="relative z-0 inline-flex rounded-md shadow-sm -space-x-px" aria-label="Pagination">
+                <a href="#" class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
+                    <span>이전</span>
+                </a>
+                <a href="#" aria-current="page" class="z-10 bg-blue-50 border-blue-500 text-blue-600 relative inline-flex items-center px-4 py-2 border text-sm font-medium">
+                    1
+                </a>
+                <a href="#" class="bg-white border-gray-300 text-gray-500 hover:bg-gray-50 relative inline-flex items-center px-4 py-2 border text-sm font-medium">
+                    2
+                </a>
+                <a href="#" class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
+                    <span>다음</span>
+                </a>
+            </nav>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `LoginForm.html` for authentication
- provide common `Header` and `Footer` fragments
- build `Layout.html` with a left side menu for Memo, Plant, Inventory, Inspection, Workorder, and Code modules

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6856aa574e408323a4d2ed0d294464cf